### PR TITLE
Fix windows issue with multiple workers

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -641,6 +641,12 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
         return NGX_ERROR;
     }
 
+#if (NGX_WIN32)
+    if (ngx_process > NGX_PROCESS_MASTER) {
+        ngx_free_listening_share(cycle);
+    }
+#endif
+
     return NGX_OK;
 }
 
@@ -905,6 +911,10 @@ ngx_close_listening_sockets(ngx_cycle_t *cycle)
 
     ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0, "[%d] close %d listener(s)",
         ngx_process, cycle->listening.nelts);
+
+#if (NGX_WIN32)
+    ngx_free_listening_share(cycle);
+#endif
 
     ngx_accept_mutex_held = 0;
     ngx_use_accept_mutex = 0;

--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -588,17 +588,6 @@ ngx_event_process_init(ngx_cycle_t *cycle)
         ngx_use_accept_mutex = 0;
     }
 
-#if (NGX_WIN32)
-
-    /*
-     * disable accept mutex on win32 as it may cause deadlock if
-     * grabbed by a process which can't accept connections
-     */
-
-    ngx_use_accept_mutex = 0;
-
-#endif
-
     ngx_queue_init(&ngx_posted_accept_events);
     ngx_queue_init(&ngx_posted_events);
 

--- a/src/os/win32/ngx_process.c
+++ b/src/os/win32/ngx_process.c
@@ -70,6 +70,10 @@ ngx_spawn_process(ngx_cycle_t *cycle, char *name, ngx_int_t respawn)
         return pid;
     }
 
+#if (NGX_WIN32)
+    ngx_share_listening_sockets(cycle, pid);
+#endif
+
     ngx_memzero(&ngx_processes[s], sizeof(ngx_process_t));
 
     ngx_processes[s].handle = ctx.child;

--- a/src/os/win32/ngx_process.c
+++ b/src/os/win32/ngx_process.c
@@ -70,9 +70,7 @@ ngx_spawn_process(ngx_cycle_t *cycle, char *name, ngx_int_t respawn)
         return pid;
     }
 
-#if (NGX_WIN32)
     ngx_share_listening_sockets(cycle, pid);
-#endif
 
     ngx_memzero(&ngx_processes[s], sizeof(ngx_process_t));
 

--- a/src/os/win32/ngx_process_cycle.c
+++ b/src/os/win32/ngx_process_cycle.c
@@ -113,11 +113,6 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
     events[2] = ngx_reopen_event;
     events[3] = ngx_reload_event;
 
-/* does not close listener for win32, will be shared */
-#if (!NGX_WIN32)
-    ngx_close_listening_sockets(cycle);
-#endif
-
     if (ngx_start_worker_processes(cycle, NGX_PROCESS_RESPAWN) == 0) {
         exit(2);
     }
@@ -209,11 +204,6 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
             }
 
             ngx_cycle = cycle;
-
-/* does not close listener for win32, will be shared */
-#if (!NGX_WIN32)
-            ngx_close_listening_sockets(cycle);
-#endif
 
             if (ngx_start_worker_processes(cycle, NGX_PROCESS_JUST_RESPAWN)) {
                 ngx_quit_worker_processes(cycle, 1);

--- a/src/os/win32/ngx_process_cycle.c
+++ b/src/os/win32/ngx_process_cycle.c
@@ -113,7 +113,10 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
     events[2] = ngx_reopen_event;
     events[3] = ngx_reload_event;
 
+/* does not close listener for win32, will be shared */
+#if (!NGX_WIN32)
     ngx_close_listening_sockets(cycle);
+#endif
 
     if (ngx_start_worker_processes(cycle, NGX_PROCESS_RESPAWN) == 0) {
         exit(2);
@@ -207,7 +210,10 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
 
             ngx_cycle = cycle;
 
+/* does not close listener for win32, will be shared */
+#if (!NGX_WIN32)
             ngx_close_listening_sockets(cycle);
+#endif
 
             if (ngx_start_worker_processes(cycle, NGX_PROCESS_JUST_RESPAWN)) {
                 ngx_quit_worker_processes(cycle, 1);

--- a/src/os/win32/ngx_socket.c
+++ b/src/os/win32/ngx_socket.c
@@ -82,6 +82,7 @@ ngx_int_t ngx_get_listening_share(ngx_cycle_t *cycle)
 ngx_shared_socket_info 
 ngx_get_listening_share_info(ngx_cycle_t *cycle, ngx_pid_t pid)
 {
+    ngx_int_t            waitint;
     ngx_int_t            waitcnt;
     ngx_shm_listener_t  *shml;
 
@@ -92,7 +93,8 @@ ngx_get_listening_share_info(ngx_cycle_t *cycle, ngx_pid_t pid)
     }
 
     /* TODO: wait time and count configurable */
-    waitcnt = 5;
+    waitcnt = 10;
+    waitint = 5;
     do {
     
         shml = (ngx_shm_listener_t *)shm_listener.addr;
@@ -100,7 +102,11 @@ ngx_get_listening_share_info(ngx_cycle_t *cycle, ngx_pid_t pid)
             break;
         }
         /* not found - wait until master process shared sockets */
-        ngx_msleep(100);
+        ngx_msleep(waitint);
+        if (waitint < 100) {
+            waitint += waitint; 
+            waitint = min(100, waitint);
+        }
     
     } while (waitcnt--);
 

--- a/src/os/win32/ngx_socket.c
+++ b/src/os/win32/ngx_socket.c
@@ -9,6 +9,18 @@
 #include <ngx_core.h>
 
 
+typedef struct {
+
+    ngx_pid_t      pid;
+    ngx_uint_t     nelts;
+
+    /* WSAPROTOCOL_INFO * [listening.nelts] */
+
+} ngx_shm_listener_t;
+
+static ngx_shm_t shm_listener = {0};
+
+
 int
 ngx_nonblocking(ngx_socket_t s)
 {
@@ -31,4 +43,130 @@ int
 ngx_tcp_push(ngx_socket_t s)
 {
     return 0;
+}
+
+
+ngx_int_t ngx_get_listening_share(ngx_cycle_t *cycle)
+{
+
+    size_t            size;
+
+    size = sizeof(ngx_shm_listener_t) +
+        sizeof(WSAPROTOCOL_INFO) * cycle->listening.nelts;
+
+    if (!shm_listener.addr || shm_listener.size < size) {
+        if (shm_listener.addr) {
+            ngx_shm_free(&shm_listener);
+        }
+
+        shm_listener.addr = NULL;
+        shm_listener.size = size;
+        shm_listener.name.len = sizeof("nginx_shared_listener") - 1;
+        shm_listener.name.data = (u_char *) "nginx_shared_listener";
+        shm_listener.log = cycle->log;
+
+        if (ngx_shm_alloc(&shm_listener) != NGX_OK) {
+            return NGX_ERROR;
+        }
+        
+        ngx_log_debug4(NGX_LOG_DEBUG_CORE, cycle->log, 0, 
+            "[%d] shared mem for %d listener(s) - %p, %d bytes", 
+            ngx_process, cycle->listening.nelts, 
+            shm_listener.addr, shm_listener.size);
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_shared_socket_info 
+ngx_get_listening_share_info(ngx_cycle_t *cycle, ngx_pid_t pid)
+{
+    ngx_int_t            waitcnt;
+    ngx_shm_listener_t  *shml;
+
+    if (shm_listener.addr == NULL) {
+        if (ngx_get_listening_share(cycle) != NGX_OK) {
+            return NULL;
+        }
+    }
+
+    /* TODO: wait time and count configurable */
+    waitcnt = 5;
+    do {
+    
+        shml = (ngx_shm_listener_t *)shm_listener.addr;
+        if (shml->pid == pid) {
+            break;
+        }
+        /* not found - wait until master process shared sockets */
+        ngx_msleep(100);
+    
+    } while (waitcnt--);
+
+    if (shml->pid != pid) {
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0, 
+            "wait for shared socket failed, process %d, found %d", pid, shml->pid);
+        return NULL;
+    }
+    if (cycle->listening.nelts > shml->nelts) {
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0, "unexpected shared len,"
+            " expected %d, but got %d", cycle->listening.nelts, shml->nelts);
+        return NULL;
+    }
+    
+    return (WSAPROTOCOL_INFO *)(shml+1);
+}
+
+
+ngx_int_t 
+ngx_share_listening_sockets(ngx_cycle_t *cycle, ngx_pid_t pid)
+{
+    ngx_uint_t           i;
+    ngx_listening_t     *ls;
+    ngx_shm_listener_t  *shml;
+    WSAPROTOCOL_INFO    *protoInfo;
+
+    if (ngx_process > NGX_PROCESS_MASTER) {
+        return NGX_OK;
+    }
+
+    ls = cycle->listening.elts;
+
+    /* create shared memory for shared listener info */
+    ngx_get_listening_share(cycle);
+
+    ngx_log_debug3(NGX_LOG_DEBUG_CORE, cycle->log, 0, 
+        "[%d] share %d listener(s) for %d",
+        ngx_process, cycle->listening.nelts, pid);
+
+    if (!cycle->listening.nelts)
+        return NGX_OK;
+
+    /* share sockets for worker with pid */
+    shml = (ngx_shm_listener_t *)shm_listener.addr;
+    protoInfo = (WSAPROTOCOL_INFO *)(shml+1);
+
+    shml->nelts = cycle->listening.nelts;
+
+    for (i = 0; i < cycle->listening.nelts; i++) {
+
+        if (ls[i].ignore) {
+            continue;
+        }
+
+        ngx_log_debug4(NGX_LOG_DEBUG_CORE, cycle->log, 0, 
+            "[%d] dup %d listener %d for %d", ngx_process, i, ls[i].fd, pid);
+
+        if (WSADuplicateSocket(ls[i].fd, pid, &protoInfo[i]) != 0) {
+            ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
+                "WSADuplicateSocket() failed");
+            return NGX_ERROR;
+        };
+
+    }
+
+    shml->pid = pid;
+
+    return NGX_OK;
 }

--- a/src/os/win32/ngx_socket.c
+++ b/src/os/win32/ngx_socket.c
@@ -79,6 +79,17 @@ ngx_int_t ngx_get_listening_share(ngx_cycle_t *cycle)
 }
 
 
+void ngx_free_listening_share(ngx_cycle_t *cycle)
+{
+    if (shm_listener.addr) {
+
+        ngx_shm_free(&shm_listener);
+        shm_listener.addr = NULL;
+
+    }
+}
+
+
 ngx_shared_socket_info 
 ngx_get_listening_share_info(ngx_cycle_t *cycle, ngx_pid_t pid)
 {

--- a/src/os/win32/ngx_socket.h
+++ b/src/os/win32/ngx_socket.h
@@ -11,6 +11,7 @@
 
 #include <ngx_config.h>
 #include <ngx_core.h>
+#include <ngx_process.h>
 
 
 #define NGX_WRITE_SHUTDOWN SD_SEND
@@ -202,6 +203,15 @@ extern LPFN_DISCONNECTEX          ngx_disconnectex;
 
 int ngx_tcp_push(ngx_socket_t s);
 #define ngx_tcp_push_n            "tcp_push()"
+
+
+typedef WSAPROTOCOL_INFO * ngx_shared_socket_info;
+#define ngx_shared_socket(af, type, proto, shinfo)                           \
+    WSASocket(af, type, proto, shinfo, 0, WSA_FLAG_OVERLAPPED)
+
+ngx_shared_socket_info ngx_get_listening_share_info(ngx_cycle_t *cycle, 
+    ngx_pid_t pid);
+ngx_int_t ngx_share_listening_sockets(ngx_cycle_t *cycle, ngx_pid_t pid);
 
 
 #endif /* _NGX_SOCKET_H_INCLUDED_ */

--- a/src/os/win32/ngx_socket.h
+++ b/src/os/win32/ngx_socket.h
@@ -211,6 +211,7 @@ typedef WSAPROTOCOL_INFO * ngx_shared_socket_info;
 
 ngx_shared_socket_info ngx_get_listening_share_info(ngx_cycle_t *cycle, 
     ngx_pid_t pid);
+void ngx_free_listening_share(ngx_cycle_t *cycle);
 ngx_int_t ngx_share_listening_sockets(ngx_cycle_t *cycle, ngx_pid_t pid);
 
 

--- a/src/os/win32/ngx_socket.h
+++ b/src/os/win32/ngx_socket.h
@@ -209,8 +209,9 @@ typedef WSAPROTOCOL_INFO * ngx_shared_socket_info;
 #define ngx_shared_socket(af, type, proto, shinfo)                           \
     WSASocket(af, type, proto, shinfo, 0, WSA_FLAG_OVERLAPPED)
 
-ngx_shared_socket_info ngx_get_listening_share_info(ngx_cycle_t *cycle, 
-    ngx_pid_t pid);
+ngx_int_t
+ngx_get_listening_share_info(ngx_cycle_t *cycle, 
+    ngx_shared_socket_info * pshinfo, ngx_pid_t pid);
 void ngx_free_listening_share(ngx_cycle_t *cycle);
 ngx_int_t ngx_share_listening_sockets(ngx_cycle_t *cycle, ngx_pid_t pid);
 


### PR DESCRIPTION
Fix windows issue with multiple workers (once listening - only one made any work),
using shared socket handles for each worker process (WSADuplicateHandle).
