### PR TITLE
always compares keys of cache entry …

### DIFF
--- a/src/http/ngx_http_cache.h
+++ b/src/http/ngx_http_cache.h
@@ -64,7 +64,6 @@ typedef struct {
 struct ngx_http_cache_s {
     ngx_file_t                       file;
     ngx_array_t                      keys;
-    uint32_t                         crc32;
     u_char                           key[NGX_HTTP_CACHE_KEY_LEN];
     u_char                           main[NGX_HTTP_CACHE_KEY_LEN];
 
@@ -119,7 +118,6 @@ typedef struct {
     time_t                           valid_sec;
     time_t                           last_modified;
     time_t                           date;
-    uint32_t                         crc32;
     u_short                          valid_msec;
     u_short                          header_start;
     u_short                          body_start;

--- a/src/http/ngx_http_cache.h
+++ b/src/http/ngx_http_cache.h
@@ -118,6 +118,8 @@ typedef struct {
     time_t                           valid_sec;
     time_t                           last_modified;
     time_t                           date;
+    /* unused - todo: delete crc32 next time cache header format changed */
+    uint32_t                         crc32;
     u_short                          valid_msec;
     u_short                          header_start;
     u_short                          body_start;


### PR DESCRIPTION
(hash is insufficient secure, so protects in case of hash collision),
  see "http://forum.nginx.org/read.php?29,261413,261529" for a discussion about;
additional protection via crc32 is obsolete and removed now;
