### PR TITLE
slab init + http file cache fixes

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -256,6 +256,11 @@ main(int argc, char *const *argv)
     if (ngx_os_init(log) != NGX_OK) {
         return 1;
     }
+    
+    /*
+     * ngx_slab_core_init() requires ngx_pagesize set in ngx_os_init()
+     */
+    ngx_slab_core_init();
 
     /*
      * ngx_crc32_table_init() requires ngx_cacheline_size set in ngx_os_init()

--- a/src/core/ngx_slab.c
+++ b/src/core/ngx_slab.c
@@ -70,13 +70,9 @@ static ngx_uint_t  ngx_slab_exact_shift;
 
 
 void
-ngx_slab_init(ngx_slab_pool_t *pool)
+ngx_slab_core_init()
 {
-    u_char           *p;
-    size_t            size;
-    ngx_int_t         m;
-    ngx_uint_t        i, n, pages;
-    ngx_slab_page_t  *slots;
+    ngx_uint_t n;
 
     /* STUB */
     if (ngx_slab_max_size == 0) {
@@ -87,6 +83,19 @@ ngx_slab_init(ngx_slab_pool_t *pool)
         }
     }
     /**/
+}
+
+
+void
+ngx_slab_init(ngx_slab_pool_t *pool)
+{
+    u_char           *p;
+    size_t            size;
+    ngx_int_t         m;
+    ngx_uint_t        i, n, pages;
+    ngx_slab_page_t  *slots;
+
+    ngx_slab_core_init();
 
     pool->min_size = 1 << pool->min_shift;
 

--- a/src/core/ngx_slab.h
+++ b/src/core/ngx_slab.h
@@ -47,6 +47,7 @@ typedef struct {
 } ngx_slab_pool_t;
 
 
+void ngx_slab_core_init();
 void ngx_slab_init(ngx_slab_pool_t *pool);
 void *ngx_slab_alloc(ngx_slab_pool_t *pool, size_t size);
 void *ngx_slab_alloc_locked(ngx_slab_pool_t *pool, size_t size);

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -129,6 +129,8 @@ ngx_http_file_cache_init(ngx_shm_zone_t *shm_zone, void *data)
     if (shm_zone->shm.exists) {
         cache->sh = cache->shpool->data;
         cache->bsize = ngx_fs_bsize(cache->path->name.data);
+        
+        cache->max_size /= cache->bsize;
 
         return NGX_OK;
     }


### PR DESCRIPTION
Closes #6

Fixes several grave bugs, described in #6 (and commit messages)

For example as consequence of the bug, the pool always allocated a full page (4K - 8K) instead of small slots inside page, so for example 1MB zone can store not more as 250 keys.

BTW. According to the documentation: One megabyte zone can store about 8 thousand keys.
- [x] Grave slab (zone pool) initialization bug: many static stubs not initialized in workers (because only master calls ngx_slab_init)
- [x] max_size still in bytes in child workers (should be in clusters), because the cache init called in master, so this large size will be "never" reached (almost ignored) - submitted a changeset to nginx-devel;
- [x] sporadically wrong counting current size of cache (too many decrease "cache->sh->size", because unlocked delete and "fcn->exists" was not reset);
- [x] if cache cannot be allocated, just because of the cache scarce - the requests failed, but imho should alert only but send the successful request data nevertheless;
