### PR TITLE
slab init + http file cache fixes

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -256,6 +256,11 @@ main(int argc, char *const *argv)
     if (ngx_os_init(log) != NGX_OK) {
         return 1;
     }
+    
+    /*
+     * ngx_slab_core_init() requires ngx_pagesize set in ngx_os_init()
+     */
+    ngx_slab_core_init();
 
     /*
      * ngx_crc32_table_init() requires ngx_cacheline_size set in ngx_os_init()

--- a/src/core/ngx_slab.c
+++ b/src/core/ngx_slab.c
@@ -70,13 +70,9 @@ static ngx_uint_t  ngx_slab_exact_shift;
 
 
 void
-ngx_slab_init(ngx_slab_pool_t *pool)
+ngx_slab_core_init()
 {
-    u_char           *p;
-    size_t            size;
-    ngx_int_t         m;
-    ngx_uint_t        i, n, pages;
-    ngx_slab_page_t  *slots;
+    ngx_uint_t n;
 
     /* STUB */
     if (ngx_slab_max_size == 0) {
@@ -87,6 +83,19 @@ ngx_slab_init(ngx_slab_pool_t *pool)
         }
     }
     /**/
+}
+
+
+void
+ngx_slab_init(ngx_slab_pool_t *pool)
+{
+    u_char           *p;
+    size_t            size;
+    ngx_int_t         m;
+    ngx_uint_t        i, n, pages;
+    ngx_slab_page_t  *slots;
+
+    ngx_slab_core_init();
 
     pool->min_size = 1 << pool->min_shift;
 

--- a/src/core/ngx_slab.h
+++ b/src/core/ngx_slab.h
@@ -47,6 +47,7 @@ typedef struct {
 } ngx_slab_pool_t;
 
 
+void ngx_slab_core_init();
 void ngx_slab_init(ngx_slab_pool_t *pool);
 void *ngx_slab_alloc(ngx_slab_pool_t *pool, size_t size);
 void *ngx_slab_alloc_locked(ngx_slab_pool_t *pool, size_t size);

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -129,6 +129,8 @@ ngx_http_file_cache_init(ngx_shm_zone_t *shm_zone, void *data)
     if (shm_zone->shm.exists) {
         cache->sh = cache->shpool->data;
         cache->bsize = ngx_fs_bsize(cache->path->name.data);
+        
+        cache->max_size /= cache->bsize;
 
         return NGX_OK;
     }

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -876,8 +876,11 @@ ngx_http_file_cache_exists(ngx_http_file_cache_t *cache, ngx_http_cache_t *c)
                                      sizeof(ngx_http_file_cache_node_t));
         if (fcn == NULL) {
             ngx_log_error(NGX_LOG_ALERT, ngx_cycle->log, 0,
-                          "could not allocate node%s", cache->shpool->log_ctx);
-            rc = NGX_ERROR;
+                "could not allocate node%s, size %d (cache: size %O / %O, count %d / %d)", 
+                cache->shpool->log_ctx, sizeof(ngx_http_file_cache_node_t),
+                (off_t)cache->sh->size, (off_t)cache->max_size, cache->sh->count, cache->sh->watermark);
+            /* cannot be cached (NGX_HTTP_CACHE_SCARCE), just use it without cache */
+            rc = NGX_AGAIN;
             goto failed;
         }
     }
@@ -1865,24 +1868,27 @@ ngx_http_file_cache_delete(ngx_http_file_cache_t *cache, ngx_queue_t *q,
         p = ngx_hex_dump(p, fcn->key, len);
         *p = '\0';
 
-        fcn->count++;
-        fcn->deleting = 1;
-        ngx_shmtx_unlock(&cache->shpool->mutex);
+        if (!fcn->deleting) {
+            fcn->count++;
+            fcn->deleting = 1;
+            fcn->exists = 0;
+            ngx_shmtx_unlock(&cache->shpool->mutex);
 
-        len = path->name.len + 1 + path->len + 2 * NGX_HTTP_CACHE_KEY_LEN;
-        ngx_create_hashed_filename(path, name, len);
+            len = path->name.len + 1 + path->len + 2 * NGX_HTTP_CACHE_KEY_LEN;
+            ngx_create_hashed_filename(path, name, len);
 
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
-                       "http file cache expire: \"%s\"", name);
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                           "http file cache expire: \"%s\"", name);
 
-        if (ngx_delete_file(name) == NGX_FILE_ERROR) {
-            ngx_log_error(NGX_LOG_CRIT, ngx_cycle->log, ngx_errno,
-                          ngx_delete_file_n " \"%s\" failed", name);
+            if (ngx_delete_file(name) == NGX_FILE_ERROR) {
+                ngx_log_error(NGX_LOG_CRIT, ngx_cycle->log, ngx_errno,
+                              ngx_delete_file_n " \"%s\" failed", name);
+            }
+
+            ngx_shmtx_lock(&cache->shpool->mutex);
+            fcn->count--;
+            fcn->deleting = 0;
         }
-
-        ngx_shmtx_lock(&cache->shpool->mutex);
-        fcn->count--;
-        fcn->deleting = 0;
     }
 
     if (fcn->count == 0) {
@@ -2001,6 +2007,7 @@ ngx_http_file_cache_manage_file(ngx_tree_ctx_t *ctx, ngx_str_t *path)
 
     if (ngx_http_file_cache_add_file(ctx, path) != NGX_OK) {
         (void) ngx_http_file_cache_delete_file(ctx, path);
+        goto done;
     }
 
     if (++cache->files >= cache->loader_files) {
@@ -2018,6 +2025,8 @@ ngx_http_file_cache_manage_file(ngx_tree_ctx_t *ctx, ngx_str_t *path)
             ngx_http_file_cache_loader_sleep(cache);
         }
     }
+
+done:
 
     return (ngx_quit || ngx_terminate) ? NGX_ABORT : NGX_OK;
 }
@@ -2079,7 +2088,7 @@ ngx_http_file_cache_add_file(ngx_tree_ctx_t *ctx, ngx_str_t *name)
         n = ngx_hextoi(p, 2);
 
         if (n == NGX_ERROR) {
-            return NGX_ERROR;
+        return NGX_ERROR;
         }
 
         p += 2;


### PR DESCRIPTION
Closes #6 (replacement for #7)

Fixes several grave bugs, described in #6 (and commit messages)

For example as consequence of the bug, the pool always allocated a full page (4K - 8K) instead of small slots inside page, so for example 1MB zone can store not more as 250 keys.

BTW. According to the documentation: One megabyte zone can store about 8 thousand keys.
- [x] Grave slab (zone pool) initialization bug: many static stubs not initialized in workers (because only master calls ngx_slab_init)
- [x] max_size still in bytes in child workers (should be in clusters), because the cache init called in master, so this large size will be "never" reached (almost ignored) - submitted a changeset to nginx-devel;
- [x] sporadically wrong counting current size of cache (too many decrease "cache->sh->size", because unlocked delete and "fcn->exists" was not reset);
- [x] if cache cannot be allocated, just because of the cache scarce - the requests failed, but imho should alert only but send the successful request data nevertheless;
