### PR TITLE
win multi worker (2nd stability fix)

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -657,6 +657,16 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
 
 #if (NGX_WIN32)
 shared_sock:
+
+            if (ngx_process > NGX_PROCESS_MASTER) {
+                /* shared (inherited) socket should be also in non-blocking mode */
+                if (ngx_nonblocking(s) == -1) {
+                    ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
+                                  ngx_nonblocking_n " %V failed",
+                                  &ls[i].addr_text);
+                }
+            }
+
 #endif
             ls[i].listen = 1;
 

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -130,6 +130,7 @@ ngx_pid_t ngx_exec_new_binary(ngx_cycle_t *cycle, char *const *argv);
 ngx_cpuset_t *ngx_get_cpu_affinity(ngx_uint_t n);
 ngx_shm_zone_t *ngx_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name,
     size_t size, void *tag);
+void ngx_process_worker_dead(ngx_pid_t pid);
 void ngx_set_shutdown_timer(ngx_cycle_t *cycle);
 
 

--- a/src/os/unix/ngx_process.c
+++ b/src/os/unix/ngx_process.c
@@ -23,7 +23,6 @@ typedef struct {
 static void ngx_execute_proc(ngx_cycle_t *cycle, void *data);
 static void ngx_signal_handler(int signo, siginfo_t *siginfo, void *ucontext);
 static void ngx_process_get_status(void);
-static void ngx_unlock_mutexes(ngx_pid_t pid);
 
 
 int              ngx_argc;
@@ -554,54 +553,8 @@ ngx_process_get_status(void)
             ngx_processes[i].respawn = 0;
         }
 
-        ngx_unlock_mutexes(pid);
-    }
-}
-
-
-static void
-ngx_unlock_mutexes(ngx_pid_t pid)
-{
-    ngx_uint_t        i;
-    ngx_shm_zone_t   *shm_zone;
-    ngx_list_part_t  *part;
-    ngx_slab_pool_t  *sp;
-
-    /*
-     * unlock the accept mutex if the abnormally exited process
-     * held it
-     */
-
-    if (ngx_accept_mutex_ptr) {
-        (void) ngx_shmtx_force_unlock(&ngx_accept_mutex, pid);
-    }
-
-    /*
-     * unlock shared memory mutexes if held by the abnormally exited
-     * process
-     */
-
-    part = (ngx_list_part_t *) &ngx_cycle->shared_memory.part;
-    shm_zone = part->elts;
-
-    for (i = 0; /* void */ ; i++) {
-
-        if (i >= part->nelts) {
-            if (part->next == NULL) {
-                break;
-            }
-            part = part->next;
-            shm_zone = part->elts;
-            i = 0;
-        }
-
-        sp = (ngx_slab_pool_t *) shm_zone[i].shm.addr;
-
-        if (ngx_shmtx_force_unlock(&sp->mutex, pid)) {
-            ngx_log_error(NGX_LOG_ALERT, ngx_cycle->log, 0,
-                          "shared memory zone \"%V\" was locked by %P",
-                          &shm_zone[i].shm.name, pid);
-        }
+        /* process is dead, call master handler for dead pid */
+        ngx_process_worker_dead(pid);
     }
 }
 

--- a/src/os/win32/ngx_process.c
+++ b/src/os/win32/ngx_process.c
@@ -182,6 +182,10 @@ ngx_spawn_process(ngx_cycle_t *cycle, char *name, ngx_int_t respawn)
 
 failed:
 
+    /* process is dead, call master handler for dead pid */
+    ngx_process_worker_dead(pid);
+
+
     if (ngx_processes[s].reopen) {
         ngx_close_handle(ngx_processes[s].reopen);
     }

--- a/src/os/win32/ngx_process_cycle.c
+++ b/src/os/win32/ngx_process_cycle.c
@@ -514,6 +514,10 @@ ngx_reap_worker(ngx_cycle_t *cycle, HANDLE h)
                       "%s process %P exited with code %Xl",
                       ngx_processes[n].name, ngx_processes[n].pid, code);
 
+
+        /* process is dead, call master handler for dead pid */
+        ngx_process_worker_dead(ngx_processes[n].pid);
+
         ngx_close_handle(ngx_processes[n].reopen);
         ngx_close_handle(ngx_processes[n].quit);
         ngx_close_handle(ngx_processes[n].term);


### PR DESCRIPTION
Small stability fix (cherry-picked from my own production branch):

* win32: if process is dead, unlock all mutexes it held (shared zones, accept mutex);
central function introduced "ngx_process_worker_dead" and "ngx_unlock_mutexes" was moved from "unix/ngx_process.c" to "core/ngx_cycle.c"
* win32: shared (inherited) socket should be also non-blocking
