### PR TITLE
[win] recognize additionally special cases if accept "fails"

### DIFF
--- a/src/os/win32/ngx_files.c
+++ b/src/os/win32/ngx_files.c
@@ -11,12 +11,10 @@
 
 #define NGX_UTF16_BUFLEN  256
 
-typedef struct _ngx_delete_file_queue_files_t ngx_delete_file_queue_files_t;
-
 typedef struct _ngx_delete_file_queue_files_t {
-    ngx_delete_file_queue_files_t *prev;
-    ngx_delete_file_queue_files_t *next;
-};
+    struct _ngx_delete_file_queue_files_t *prev;
+    struct _ngx_delete_file_queue_files_t *next;
+} ngx_delete_file_queue_files_t;
 
 static struct {
     ngx_delete_file_queue_files_t *first;


### PR DESCRIPTION
[win] recognize additionally special cases if accept "fails":

- EINPROGRESS - blocking call in progress, or still processing a callback inside service provider
- ECONNRESET - incoming connection reset by peer, before it could be accepted

Just for better "error" handling and as try to fix #10